### PR TITLE
Rename First Class service names to use the names as they appear via …

### DIFF
--- a/lib/endicia_label_server/services.rb
+++ b/lib/endicia_label_server/services.rb
@@ -12,8 +12,8 @@ module EndiciaLabelServer
     'CriticalMail' => 'Critical Mail',
     'ExpressMailInternational' => 'Express Mail International',
     'PriorityMailExpressInternational' => 'Priority Mail Express International',
-    'FirstClassMailInternational' => 'First-Class Mail International',
-    'FirstClassPackageInternatiionalService' => 'First-Class Package International Service',
+    'FirstClassMailInternational' => 'First Class Mail International',
+    'FirstClassPackageInternationalService' => 'First Class Package International Service',
     'PriorityMailInternational' => 'Priority Mail International',
     'PriorityMailFlatRateEnvelope' => 'Priority Mail Flat Rate Envelope',
     'PriorityMailExpressFlatRateEnvelope' => 'Priority Mail Express Flat Rate Envelope'


### PR DESCRIPTION
…the Endicia API

This resolves the problem where the service isn't fully resolved and therefore doesn't return the correct service code.

Also fixed a typo where FirstClassPackageInternatiionalService => FirstClassPackageInternationalService